### PR TITLE
Add an optional second argument for monitorremoved event

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::os::unix::net::UnixStream;
 use std::process::Command; // execute system command
 
 // listen Hyprland socket
-fn listen(socket_addr: String) -> std::io::Result<()> {
+fn listen(socket_addr: String, script_attached: &str, script_detached: Option<&str>) -> std::io::Result<()> {
     let stream = match UnixStream::connect(socket_addr) {
         Ok(stream) => stream,
         Err(e) => {
@@ -28,9 +28,18 @@ fn listen(socket_addr: String) -> std::io::Result<()> {
         let data_parts: Vec<&str> = data.trim().split(">>").collect();
         if data_parts[0] == "monitoradded" {
             Command::new("/bin/sh")
+                .arg(script_attached)
                 .args(args.clone())
                 .spawn()
                 .expect("Failed to execute command");
+        } else if data_parts[0] == "monitorremoved" {
+            if let Some(script_detached) = script_detached {
+                Command::new("/bin/sh")
+                    .arg(script_detached)
+                    .args(args.clone())
+                    .spawn()
+                    .expect("Failed to execute command");
+            }
         }
     }
 }
@@ -40,8 +49,10 @@ fn main() {
     match env::var("HYPRLAND_INSTANCE_SIGNATURE") {
         Ok(val) => {
             let socket = format!("/tmp/hypr/{}/.socket2.sock", val);
+            let script_attached = std::env::args().nth(1).expect("Missing script for monitor attached");
+            let script_detached = std::env::args().nth(2);
             // listen Hyprland socket
-            match listen(socket) {
+            match listen(socket, &script_attached, script_detached.as_deref()) {
                 Ok(()) => {}
                 Err(..) => {}
             }


### PR DESCRIPTION
## Description

I needed both monitoradded and monitorremoved events, i thought this could be useful to more people.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Tested on Hyprland, built from branch master at commit 51a930f802c71a0e67f05e7b176ded74e8e95f87  (update to v 0.26.0).
Tag: v0.26.0

