### PR TITLE
feat: Allow scripts other than bash

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,15 +26,13 @@ fn listen(socket_addr: String, script_attached: &str, script_detached: Option<&s
         let data = String::from_utf8_lossy(&buf);
         let data_parts: Vec<&str> = data.trim().split(">>").collect();
         if data_parts[0] == "monitoradded" {
-            Command::new("/bin/sh")
-                .arg(script_attached)
+            Command::new(script_attached)
                 .args([data_parts[1]])
                 .spawn()
                 .expect("Failed to execute command");
         } else if data_parts[0] == "monitorremoved" {
             if let Some(script_detached) = script_detached {
-                Command::new("/bin/sh")
-                    .arg(script_detached)
+                Command::new(script_detached)
                     .args([data_parts[1]])
                     .spawn()
                     .expect("Failed to execute command");


### PR DESCRIPTION
## Description

This allows scripts other than bash to be used (fish/python etc), or any executable really. All it does is remove the direct call to /bin/sh, pushing that back into the shebang within the script.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have been running this for a bit over a week with a bunch of fish scripts and it has been working well. I've also tested a bash script which works as expected.